### PR TITLE
Update spec after implementing key list

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -12,7 +12,6 @@ An open source band management application
 * Copy a SetList to a new one
 * Drag-and-drop to add Songs to a SetList
 * Song search/filter in list
-* Pick List for Song.key
 * Tag handling for Songs, SetLists, Gigs, Venues etc
 * Sidebar
 * Google Maps embed


### PR DESCRIPTION
## Summary
- remove the `Pick List for Song.key` item from `spec.md` since the
  codebase already implements it via `KEY_OPTIONS` and a test

## Testing
- `pip install --break-system-packages -r requirements/development-requirements.txt`
- `pytest -q` *(fails: no tests found)*
- `python3 manage.py test -v 2` *(fails: database not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68829c74c8cc8326a90e14d6794d4ddc