### PR TITLE
Add setlist copy feature

### DIFF
--- a/bandapp/models.py
+++ b/bandapp/models.py
@@ -64,6 +64,17 @@ class Setlist(TimeStampedModel):
     def __str__(self):
         return self.title
 
+    def copy(self):
+        """Create a duplicate of this setlist including songs and tags."""
+        copy_title = f"{self.title} (Copy)"
+        new_setlist = Setlist.objects.create(
+            title=copy_title,
+            description=self.description,
+        )
+        new_setlist.songs.set(self.songs.all())
+        new_setlist.tags.set(self.tags.all())
+        return new_setlist
+
 class Band(models.Model):
     """
     Band model

--- a/bandapp/templates/bandapp/setlist_list.html
+++ b/bandapp/templates/bandapp/setlist_list.html
@@ -7,6 +7,7 @@
       <th>Title</th>
       <th>Songs Count</th>
       <th>tags</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -14,6 +15,10 @@
     <tr>
       <td data-label="setlist.title">{{ setlist.title }}</td>
       <td data-label="setlist.songs.count">{{ setlist.songs.count }}</td>
+      <td></td>
+      <td>
+        <a href="{% url 'setlist-copy' setlist.pk %}" class="ui button">Copy</a>
+      </td>
     </tr>
   {% empty %}
   <tr class="disabled"><td>No setlists yet</td></tr>

--- a/bandapp/tests.py
+++ b/bandapp/tests.py
@@ -1,10 +1,50 @@
 from django.test import TestCase
+from django.conf import settings
 
-from .models import Song
+from django.urls import reverse
+
+from .models import Song, Setlist, Tag
 from .constants import KEY_OPTIONS
+
+
+settings.DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
 
 
 class SongModelTest(TestCase):
     def test_key_choices(self):
         field = Song._meta.get_field("key")
         self.assertEqual(field.choices, KEY_OPTIONS)
+
+
+class SetlistCopyTest(TestCase):
+    def setUp(self):
+        self.song1 = Song.objects.create(title="Song 1")
+        self.song2 = Song.objects.create(title="Song 2")
+        self.tag = Tag.objects.create(text="rock")
+        self.setlist = Setlist.objects.create(title="My Set", description="d")
+        self.setlist.songs.set([self.song1, self.song2])
+        self.setlist.tags.add(self.tag)
+
+    def test_copy_method(self):
+        new_setlist = self.setlist.copy()
+        self.assertEqual(new_setlist.title, "My Set (Copy)")
+        self.assertQuerySetEqual(
+            new_setlist.songs.order_by("id"),
+            list(self.setlist.songs.order_by("id")),
+            ordered=True,
+        )
+        self.assertQuerySetEqual(
+            new_setlist.tags.order_by("id"),
+            list(self.setlist.tags.order_by("id")),
+            ordered=True,
+        )
+
+    def test_copy_view(self):
+        response = self.client.get(reverse("setlist-copy", args=[self.setlist.pk]))
+        self.assertRedirects(response, reverse("setlist-list"))
+        self.assertEqual(Setlist.objects.count(), 2)

--- a/bandapp/views.py
+++ b/bandapp/views.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404, redirect
 from django.views.generic.list import ListView
 from django.views.generic import CreateView
 from django.contrib.auth.forms import UserCreationForm
@@ -44,3 +44,10 @@ class SignUpView(CreateView):
 def sandbox(request):
     context = {}
     return render(request, 'bandapp/sandbox.html', context)
+
+
+def copy_setlist(request, pk):
+    """Duplicate a setlist and redirect to the setlist list."""
+    setlist = get_object_or_404(Setlist, pk=pk)
+    setlist.copy()
+    return redirect('setlist-list')

--- a/bandmanager/settings_test.py
+++ b/bandmanager/settings_test.py
@@ -1,0 +1,8 @@
+from .settings import *
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}

--- a/bandmanager/urls.py
+++ b/bandmanager/urls.py
@@ -22,6 +22,7 @@ from bandapp.views import (
     SetlistListView,
     SignUpView,
     SongListView,
+    copy_setlist,
     )
 
 admin.site.site_header = "Band Manager"
@@ -32,6 +33,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('accounts/', include("django.contrib.auth.urls")),
     path('signup/', SignUpView.as_view(), name="signup"),
+    path('setlists/<uuid:pk>/copy/', copy_setlist, name="setlist-copy"),
     path('setlists/', SetlistListView.as_view(), name="setlist-list"),
     path('songs/', SongListView.as_view(), name="song-list"),
     path('gigs/', SetlistListView.as_view(), name="setlist-list"),

--- a/spec.md
+++ b/spec.md
@@ -9,7 +9,6 @@ An open source band management application
 ## Features
 
 ## Roadmap (features it would be nice to have but not currently planned)
-* Copy a SetList to a new one
 * Drag-and-drop to add Songs to a SetList
 * Song search/filter in list
 * Tag handling for Songs, SetLists, Gigs, Venues etc


### PR DESCRIPTION
## Summary
- implement `Setlist.copy()` method
- add view and URL for copying a setlist
- display copy button in setlist list
- create SQLite-based test settings and update tests
- remove completed roadmap item

## Testing
- `python3 manage.py test bandapp.tests -v 2 --settings=bandmanager.settings_test`

------
https://chatgpt.com/codex/tasks/task_e_68829dd788c88326abb85feb09988e09