### PR TITLE
Add drag and drop setlist editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # band-manager
 
-a Django app for managing a band's set lists, repertoire, and gigs.
+
+A Django app for managing a band's set lists, repertoire, and gigs.
+
+## Features
+
+- Manage your song repertoire with tempo, key, notes and useful links
+- Organise songs into ordered setlists
+- Duplicate existing setlists
+- Record gigs with date and location information
+- User signup and login out of the box
+- **Drag-and-drop** to add songs to a setlist

--- a/bandapp/templates/bandapp/setlist_detail.html
+++ b/bandapp/templates/bandapp/setlist_detail.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>{{ object.title }}</h1>
+
+<div class="ui grid">
+  <div class="eight wide column">
+    <h3>Setlist Songs</h3>
+    <table id="setlist-songs" class="ui celled table">
+      <thead>
+        <tr>
+          <th>Title</th>
+          <th>Original Artist</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for song in object.songs.all %}
+        <tr>
+          <td>{{ song.title }}</td>
+          <td>{{ song.original_artist }}</td>
+        </tr>
+        {% empty %}
+        <tr class="disabled"><td colspan="2">No songs yet</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="eight wide column">
+    <h3>All Songs</h3>
+    <table class="ui celled table">
+      <thead>
+        <tr>
+          <th>Title</th>
+          <th>Original Artist</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for song in songs %}
+        <tr class="song-item" data-song-id="{{ song.id }}">
+          <td>{{ song.title }}</td>
+          <td>{{ song.original_artist }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+  document.querySelectorAll('.song-item').forEach(function(el){
+    el.draggable = true;
+    el.addEventListener('dragstart', function(ev){
+      ev.dataTransfer.setData('text/plain', el.dataset.songId);
+    });
+  });
+
+  var dropZone = document.getElementById('setlist-songs');
+  dropZone.addEventListener('dragover', function(ev){
+    ev.preventDefault();
+  });
+  dropZone.addEventListener('drop', function(ev){
+    ev.preventDefault();
+    const songId = ev.dataTransfer.getData('text/plain');
+    fetch('{% url "setlist-add-song" object.pk %}', {
+      method: 'POST',
+      headers: {
+        'X-CSRFToken': '{{ csrf_token }}',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: 'song_id=' + songId
+    }).then(function(){
+      window.location.reload();
+    });
+  });
+</script>
+{% endblock content %}

--- a/bandapp/tests.py
+++ b/bandapp/tests.py
@@ -48,3 +48,16 @@ class SetlistCopyTest(TestCase):
         response = self.client.get(reverse("setlist-copy", args=[self.setlist.pk]))
         self.assertRedirects(response, reverse("setlist-list"))
         self.assertEqual(Setlist.objects.count(), 2)
+
+
+class AddSongToSetlistTest(TestCase):
+    def setUp(self):
+        self.song1 = Song.objects.create(title="Song 1")
+        self.setlist = Setlist.objects.create(title="My Set")
+
+    def test_add_song_view(self):
+        url = reverse("setlist-add-song", args=[self.setlist.pk])
+        response = self.client.post(url, {"song_id": self.song1.pk})
+        self.assertEqual(response.status_code, 200)
+        self.setlist.refresh_from_db()
+        self.assertIn(self.song1, self.setlist.songs.all())

--- a/bandmanager/urls.py
+++ b/bandmanager/urls.py
@@ -20,9 +20,11 @@ from bandapp.views import (
     index,
     sandbox,
     SetlistListView,
+    SetlistDetailView,
     SignUpView,
     SongListView,
     copy_setlist,
+    add_song_to_setlist,
     )
 
 admin.site.site_header = "Band Manager"
@@ -34,6 +36,8 @@ urlpatterns = [
     path('accounts/', include("django.contrib.auth.urls")),
     path('signup/', SignUpView.as_view(), name="signup"),
     path('setlists/<uuid:pk>/copy/', copy_setlist, name="setlist-copy"),
+    path('setlists/<uuid:pk>/add-song/', add_song_to_setlist, name='setlist-add-song'),
+    path('setlists/<uuid:pk>/', SetlistDetailView.as_view(), name='setlist-detail'),
     path('setlists/', SetlistListView.as_view(), name="setlist-list"),
     path('songs/', SongListView.as_view(), name="song-list"),
     path('gigs/', SetlistListView.as_view(), name="setlist-list"),


### PR DESCRIPTION
## Summary
- implement Setlist detail view with drag and drop
- enable adding songs via AJAX
- update URLs for new endpoints
- extend test coverage for new view
- document features in README

## Testing
- `python3 manage.py test --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6882a07ffd2c8326aafe062af5bb6828